### PR TITLE
5pm-2 hkk - added Heroku production app and dashboard links to README.md & set up Google OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# team04-w22-5pm-courses
+# s22-5pm-courses
 
 [![codecov](https://codecov.io/gh/ucsb-cs156-w22/team04-w22-5pm-courses/branch/main/graph/badge.svg?token=LvEIQ6tYti)](https://codecov.io/gh/ucsb-cs156-w22/team04-w22-5pm-courses)
+
+* Heroku production app: <https://s22-5pm-courses.herokuapp.com/>
+
+* Heroku dashboard URL: <https://dashboard.heroku.com/apps/s22-5pm-courses/>
 
 Storybook is here:
 * Production: <https://ucsb-cs156-w22.github.io/team04-w22-5pm-courses-docs/>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# s22-5pm-courses
+# proj01-s22-5pm-courses
 
 [![codecov](https://codecov.io/gh/ucsb-cs156-w22/team04-w22-5pm-courses/branch/main/graph/badge.svg?token=LvEIQ6tYti)](https://codecov.io/gh/ucsb-cs156-w22/team04-w22-5pm-courses)
 


### PR DESCRIPTION
# Overview

In this PR,

1. Add Heroku production app link to README.md
2. Add Heroku production app dashboard link to README.md
3. a) Set up Google OAuth credentials that work on `http://localhost:8080`
3. b) ... that work on `Heroku production deployment`

# Issues Addressed

Closes #3 
Closes #4 
