### PR TITLE
5pm-1 cs - update codecov token to link to correct repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # team04-w22-5pm-courses
 
-[![codecov](https://codecov.io/gh/ucsb-cs156-w22/team04-w22-5pm-courses/branch/main/graph/badge.svg?token=LvEIQ6tYti)](https://codecov.io/gh/ucsb-cs156-w22/team04-w22-5pm-courses)
+[![codecov](https://codecov.io/gh/ucsb-cs156-s22/s22-5pm-courses/branch/main/graph/badge.svg?token=XVVkeMISkP)](https://codecov.io/gh/ucsb-cs156-s22/s22-5pm-courses)
 
 Storybook is here:
 * Production: <https://ucsb-cs156-w22.github.io/team04-w22-5pm-courses-docs/>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# team04-w22-5pm-courses
+# proj01-s22-5pm-courses
 
 [![codecov](https://codecov.io/gh/ucsb-cs156-s22/s22-5pm-courses/branch/main/graph/badge.svg?token=XVVkeMISkP)](https://codecov.io/gh/ucsb-cs156-s22/s22-5pm-courses)
 


### PR DESCRIPTION
this PR changes the codecov token in the README to link to the code coverage for s22-5pm-courses. Also updates the heading in the README. closes #2 