### PR TITLE
s22-5pm-1 cs - fix frontend tests so that red error blocks do not show

### DIFF
--- a/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/BasicCourseSearchForm.test.js
@@ -33,6 +33,8 @@ describe("BasicCourseSearchForm tests", () => {
     toast.mockReturnValue({
       addToast: addToast,
     });
+    jest.spyOn(console, 'error')
+    console.error.mockImplementation(() => null);
   });
 
   test("renders without crashing", () => {

--- a/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
+++ b/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
@@ -17,10 +17,13 @@ jest.mock("react", () => ({
 describe("SingleSubjectDropdown tests", () => {
   beforeEach(() => {
     useState.mockImplementation(jest.requireActual("react").useState);
+    jest.spyOn(console, 'error')
+    console.error.mockImplementation(() => null);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+    console.error.mockRestore()
   });
 
   const subject = jest.fn();

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -32,8 +32,14 @@ describe("HomePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
+    jest.spyOn(console, 'error')
+    console.error.mockImplementation(() => null);
   });
 
+  afterEach(() => {
+    console.error.mockRestore();
+  });
+  
   const queryClient = new QueryClient();
   test("renders without crashing", () => {
     render(


### PR DESCRIPTION
This PR fixes an issue where walls of red error text would show when running frontend tests, even with all tests passing due to the tests setting up backend failures. To resolve this, `jest.spyOn(console, 'error')` and `console.error.mockImplementation(() => null);` were added to the beforeEach() blocks and `console.error.mockRestore()` was added to the afterEach() blocks of tests that were problematic. Now the tests output all green passing tests without the red walls of error text.

<img width="654" alt="Screen Shot 2022-05-30 at 9 00 00 PM" src="https://user-images.githubusercontent.com/49623072/171090162-06b5dc7f-e12c-4241-995c-6a9eabb20dc4.png">

Closes #35 
