### PR TITLE
s22-5pm-2 jj Removed addedCourses list from PersonalSchedule entity

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/entities/PersonalSchedule.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/PersonalSchedule.java
@@ -33,7 +33,4 @@ public class PersonalSchedule {
   private String description;
   private String quarter;
 
-  @OneToMany(mappedBy="personalSchedule")
-  private List<AddedCourse> addedCourses;
-  
 }


### PR DESCRIPTION
Removed the List<AddedCourse> addedCourses field from the PersonalSchedule entity, solving the backend 500 error after a new PersonalSchedule is inserted