### PR TITLE
s22-5pm-1 Implemented Sections Search Table

### DIFF
--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -1,0 +1,46 @@
+import React from "react";
+import OurTable from "main/components/OurTable";
+
+export default function SectionsTable({ sections }) {
+
+    const columns = [
+        {
+            Header: 'Quarter',
+            accessor: 'courseInfo.quarter',
+        },
+        {
+            Header: 'Course Number',
+            accessor: 'courseInfo.courseId',
+        },
+        {
+            Header: 'Course Title',
+            accessor: 'courseInfo.title',
+        },
+        {
+            Header: 'Days',
+            accessor: 'section.timeLocations[0].days',
+        },
+        {
+            Header: 'Begin Time',
+            accessor: 'section.timeLocations[0].beginTime',
+        },
+        {
+            Header: 'End Time',
+            accessor: 'section.timeLocations[0].endTime',
+        },
+        {
+            Header: 'Enrolled',
+            accessor: 'section.enrolledTotal',
+        },
+        {
+            Header: 'Max. Enrollment',
+            accessor: 'section.maxEnroll',
+        },
+    ];
+
+    return <OurTable
+        data={sections}
+        columns={columns}
+        testid={"SectionsTable"}
+    />;
+};

--- a/frontend/src/stories/components/Sections/SectionsTable.stories.js
+++ b/frontend/src/stories/components/Sections/SectionsTable.stories.js
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import SectionsTable from 'main/components/Sections/SectionsTable';
+import { sectionsFixtures } from 'fixtures/sectionsFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+
+export default {
+    title: 'components/Sections/SectionsTable',
+    component: SectionsTable
+};
+
+const Template = (args) => {
+    return (
+        <SectionsTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    sections: []
+};
+
+export const ThreeSections = Template.bind({});
+
+ThreeSections.args = {
+    sections: sectionsFixtures.threeSections
+};
+
+
+export const ThreeSectionsUser = Template.bind({});
+ThreeSectionsUser.args = {
+    sections: sectionsFixtures.threeSections,
+    currentUser: currentUserFixtures.adminUser
+};

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -1,0 +1,128 @@
+import { _fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import SectionsTable from "main/components/Sections/SectionsTable";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { sectionsFixtures } from "fixtures/sectionsFixtures";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+const mockedMutate = jest.fn();
+
+jest.mock('main/utils/useBackend', () => ({
+    ...jest.requireActual('main/utils/useBackend'),
+    useBackendMutation: () => ({ mutate: mockedMutate })
+}));
+
+describe("UserTable tests", () => {
+    const queryClient = new QueryClient();
+
+    test("renders without crashing for empty table with user not logged in", () => {
+        const currentUser = null;
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <SectionsTable sections={[]} currentUser={currentUser} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("renders without crashing for empty table for ordinary user", () => {
+        const currentUser = currentUserFixtures.userOnly;
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <SectionsTable sections={[]} currentUser={currentUser} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("renders without crashing for empty table for admin", () => {
+        const currentUser = currentUserFixtures.adminUser;
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <SectionsTable sections={[]} currentUser={currentUser} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("Has the expected column headers and content for Ordinary User", async() => {
+
+        const currentUser = currentUserFixtures.userOnly;
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <SectionsTable sections={sectionsFixtures.threeSections} currentUser={currentUser} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const expectedHeaders = ["Quarter", "Course Number", "Course Title", "Days", "Begin Time", "End Time", 
+        "Enrolled", "Max. Enrollment"];
+        const expectedFields = ["courseInfo.quarter", "courseInfo.courseId", "courseInfo.title", "section.timeLocations[0].days", 
+        "section.timeLocations[0].beginTime", "section.timeLocations[0].endTime", "section.enrolledTotal", "section.maxEnroll"];
+        const testId = "SectionsTable";
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expectedFields.forEach((field) => {
+            const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+            expect(header).toBeInTheDocument();
+        });
+
+        await waitFor( ()=> expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("CMPSC 8"));
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-courseInfo.courseId`)).toHaveTextContent("CMPSC 9");
+
+    });
+
+    test("Has the expected column headers and content for adminUser", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <SectionsTable sections={sectionsFixtures.threeSections} currentUser={currentUser} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const expectedHeaders = ["Quarter", "Course Number", "Course Title", "Days", "Begin Time", "End Time", 
+        "Enrolled", "Max. Enrollment"];
+        const expectedFields = ["courseInfo.quarter", "courseInfo.courseId", "courseInfo.title", "section.timeLocations[0].days", 
+        "section.timeLocations[0].beginTime", "section.timeLocations[0].endTime", "section.enrolledTotal", "section.maxEnroll"];
+        const testId = "SectionsTable";
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expectedFields.forEach((field) => {
+            const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+            expect(header).toBeInTheDocument();
+        });
+
+        await waitFor( () => expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("CMPSC 8"));
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-courseInfo.courseId`)).toHaveTextContent("CMPSC 9");
+
+    });
+
+});


### PR DESCRIPTION
In this PR, we introduce the `SectionTable` component, along with stories and tests.

It will be used in later PRs for searching for sections (i.e. in PR53) and for listing sections.
Passed all tests.
Link to storybook: https://ucsb-cs156-s22.github.io/s22-5pm-courses-docs-qa/storybook-qa/5pm-1-SectionsTable-fix/?path=/story/components-sections-sectionstable--three-sections/

Screenshot of Table working
<img width="1432" alt="image" src="https://user-images.githubusercontent.com/77415714/172029668-395558d8-3f36-4ad3-bed5-cb5bb6829aca.png">



