### PR TITLE
S22-5pm-2 RV - Add API endpoint for getting section information from a schedule

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/AddedCoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/AddedCoursesController.java
@@ -50,14 +50,14 @@ import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 public class AddedCoursesController extends ApiController {
 
     @Autowired
-    PersonalScheduleRepository personalscheduleRepository;
+    PersonalScheduleRepository personalScheduleRepository;
 
     @Autowired
     AddedCourseRepository addedCourseRepository;
 
     @Autowired
     UCSBCurriculumService ucsbCurriculumService;
-  
+
     @ApiOperation(value = "Create a new course")
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/post")
@@ -104,8 +104,7 @@ public class AddedCoursesController extends ApiController {
     public ResponseEntity<List<String>> thisScheduleSections(
             @ApiParam("id") @RequestParam Long id
     ) {
-        System.out.println("Hello, testing admin");
-        PersonalSchedule personalSchedule = personalscheduleRepository.findById(id)
+        PersonalSchedule personalSchedule = personalScheduleRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
 
         var quarter = personalSchedule.getQuarter();
@@ -129,7 +128,7 @@ public class AddedCoursesController extends ApiController {
     public ResponseEntity<List<String>> thisUserSections(
             @ApiParam("id") @RequestParam Long id) {
         User currentUser = getCurrentUser().getUser();
-        PersonalSchedule personalSchedule = personalscheduleRepository.findByIdAndUser(id, currentUser)
+        PersonalSchedule personalSchedule = personalScheduleRepository.findByIdAndUser(id, currentUser)
           .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
 
         var quarter = personalSchedule.getQuarter();

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/AddedCoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/AddedCoursesController.java
@@ -11,6 +11,8 @@ import edu.ucsb.cs156.courses.repositories.AddedCourseRepository;
 
 import edu.ucsb.cs156.courses.entities.AddedCourse;
 
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -101,7 +103,7 @@ public class AddedCoursesController extends ApiController {
     @ApiOperation(value = "Get sections from a single schedule")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/admin")
-    public ResponseEntity<List<String>> thisScheduleSections(
+    public ResponseEntity<List<ConvertedSection>> thisScheduleSections(
             @ApiParam("id") @RequestParam Long id
     ) {
         PersonalSchedule personalSchedule = personalScheduleRepository.findById(id)
@@ -109,13 +111,13 @@ public class AddedCoursesController extends ApiController {
 
         var quarter = personalSchedule.getQuarter();
         Iterable<AddedCourse> classesAdded = addedCourseRepository.findAllByPersonalSchedule(personalSchedule);
-        List<String> listOfJSON = new ArrayList<>();
+        List<ConvertedSection> listOfJSON = new ArrayList<>();
 
         for(AddedCourse currentClass : classesAdded)
         {
             String enrollCode = currentClass.getEnrollCd();
-            String currentSection = ucsbCurriculumService.getSectionJSON(quarter, enrollCode);
-            listOfJSON.add(currentSection);
+            ConvertedSection currentSectionString = ucsbCurriculumService.getConvertedSection(quarter, enrollCode);
+            listOfJSON.add(currentSectionString);
         }
 
         return ResponseEntity.ok().body(listOfJSON);
@@ -125,7 +127,7 @@ public class AddedCoursesController extends ApiController {
     @ApiOperation(value = "Get sections from a single schedule (if it belongs to current user)")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("")
-    public ResponseEntity<List<String>> thisUserSections(
+    public ResponseEntity<List<ConvertedSection>> thisUserSections(
             @ApiParam("id") @RequestParam Long id) {
         User currentUser = getCurrentUser().getUser();
         PersonalSchedule personalSchedule = personalScheduleRepository.findByIdAndUser(id, currentUser)
@@ -133,12 +135,12 @@ public class AddedCoursesController extends ApiController {
 
         var quarter = personalSchedule.getQuarter();
         Iterable<AddedCourse> classesAdded = addedCourseRepository.findAllByPersonalSchedule(personalSchedule);
-        List<String> listOfJSON = new ArrayList<>();
+        List<ConvertedSection> listOfJSON = new ArrayList<>();
         for(AddedCourse currentClass : classesAdded)
         {
             String enrollCode = currentClass.getEnrollCd();
-            String currentSection = ucsbCurriculumService.getSectionJSON(quarter, enrollCode);
-            listOfJSON.add(currentSection);
+            ConvertedSection currentSectionString = ucsbCurriculumService.getConvertedSection(quarter, enrollCode);
+            listOfJSON.add(currentSectionString);
         }
 
         return ResponseEntity.ok().body(listOfJSON);

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/AddedCoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/AddedCoursesController.java
@@ -1,0 +1,106 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import edu.ucsb.cs156.courses.entities.PersonalSchedule;
+import edu.ucsb.cs156.courses.entities.AddedCourse;
+import edu.ucsb.cs156.courses.entities.User;
+import edu.ucsb.cs156.courses.errors.EntityNotFoundException;
+import edu.ucsb.cs156.courses.models.CurrentUser;
+import edu.ucsb.cs156.courses.repositories.PersonalScheduleRepository;
+
+import edu.ucsb.cs156.courses.repositories.AddedCourseRepository;
+
+import edu.ucsb.cs156.courses.entities.AddedCourse;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Collections;
+import java.util.ArrayList;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.Optional;
+
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+
+@Api(description = "AddedCourses")
+@RequestMapping("/api/addedcourses")
+@RestController
+@Slf4j
+public class AddedCoursesController extends ApiController {
+
+    @Autowired
+    PersonalScheduleRepository personalscheduleRepository;
+
+    @Autowired
+    AddedCourseRepository addedCourseRepository;
+
+    @Autowired
+    UCSBCurriculumService ucsbCurriculumService;
+
+    @ApiOperation(value = "Get sections from a single schedule")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/admin")
+    public ResponseEntity<List<String>> thisScheduleSections(
+            @ApiParam("id") @RequestParam Long id
+    ) {
+        System.out.println("Hello, testing admin");
+        PersonalSchedule personalSchedule = personalscheduleRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
+
+        var quarter = personalSchedule.getQuarter();
+        Iterable<AddedCourse> classesAdded = addedCourseRepository.findAllByPersonalSchedule(personalSchedule);
+        List<String> listOfJSON = new ArrayList<>();
+
+        for(AddedCourse currentClass : classesAdded)
+        {
+            String enrollCode = currentClass.getEnrollCd();
+            String currentSection = ucsbCurriculumService.getSectionJSON(quarter, enrollCode);
+            listOfJSON.add(currentSection);
+        }
+
+        return ResponseEntity.ok().body(listOfJSON);
+    }
+
+
+    @ApiOperation(value = "Get sections from a single schedule (if it belongs to current user)")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public ResponseEntity<List<String>> thisUserSections(
+            @ApiParam("id") @RequestParam Long id) {
+        User currentUser = getCurrentUser().getUser();
+        PersonalSchedule personalSchedule = personalscheduleRepository.findByIdAndUser(id, currentUser)
+          .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
+
+        var quarter = personalSchedule.getQuarter();
+        Iterable<AddedCourse> classesAdded = addedCourseRepository.findAllByPersonalSchedule(personalSchedule);
+        List<String> listOfJSON = new ArrayList<>();
+        for(AddedCourse currentClass : classesAdded)
+        {
+            String enrollCode = currentClass.getEnrollCd();
+            String currentSection = ucsbCurriculumService.getSectionJSON(quarter, enrollCode);
+            listOfJSON.add(currentSection);
+        }
+
+        return ResponseEntity.ok().body(listOfJSON);
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Course.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Course.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.courses.documents;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.ArrayList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,4 +28,26 @@ public class Course {
     private List<Section> classSections;
     private List<GeneralEducation> generalEducation;
     private FinalExam finalExam;
-} 
+
+    public List<ConvertedSection> convertedSections() {
+
+        List<ConvertedSection> result = new ArrayList<ConvertedSection>();
+
+        CourseInfo courseInfo = CourseInfo.builder()
+                .quarter(this.getQuarter())
+                .courseId(this.getCourseId())
+                .title(this.getTitle())
+                .description(this.getDescription())
+                .build();
+
+        for (Section section : this.getClassSections()) {
+            ConvertedSection cs = ConvertedSection.builder()
+                    .courseInfo(courseInfo)
+                    .section(section)
+                    .build();
+            result.add(cs);
+
+        }
+        return result;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/CoursePage.java
@@ -23,7 +23,7 @@ public class CoursePage {
 
     /**
      * Create a CoursePage object from json representation
-     * 
+     *
      * @param json String of json returned by API endpoint {@code /classes/search}
      * @return a new CoursePage object
      * @see <a href=
@@ -44,7 +44,7 @@ public class CoursePage {
 
     /**
      * Create a List<ConvertedSection> from json representation
-     * 
+     *
      * @param json String of json returned by API endpoint {@code /classes/search}
      * @return a new CoursePage object
      * @see <a href=
@@ -55,22 +55,9 @@ public class CoursePage {
         List<ConvertedSection> result = new ArrayList<ConvertedSection>();
 
         for (Course c : this.getClasses()) {
-            for (Section section : c.getClassSections()) {
-                CourseInfo courseInfo = CourseInfo.builder()
-                        .quarter(c.getQuarter())
-                        .courseId(c.getCourseId())
-                        .title(c.getTitle())
-                        .description(c.getDescription())
-                        .build();
-                ConvertedSection cs = ConvertedSection.builder()
-                        .courseInfo(courseInfo)
-                        .section(section)
-                        .build();
-                result.add(cs);
-
-            }
+            result.addAll(c.convertedSections());
         }
         return result;
     }
 
-} 
+}

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -24,6 +24,7 @@ import org.springframework.web.client.RestTemplate;
 
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CoursePage;
+import edu.ucsb.cs156.courses.documents.Course;
 
 /**
  * Service object that wraps the UCSB Academic Curriculum API
@@ -95,7 +96,7 @@ public class UCSBCurriculumService  {
             throws JsonProcessingException {
         String json = getJSON(subjectArea, quarter, courseLevel);
         CoursePage coursePage = objectMapper.readValue(json, CoursePage.class);
-        List<ConvertedSection> sections = coursePage.convertedSections();  
+        List<ConvertedSection> sections = coursePage.convertedSections();
         String convertedSection = objectMapper.writeValueAsString(sections);
         return convertedSection;
     }
@@ -163,4 +164,18 @@ public class UCSBCurriculumService  {
         return retVal;
     }
 
+    public ConvertedSection getConvertedSection(String quarter, String enrollCode) {
+        String rawSectionJSON = getSectionJSON(quarter, enrollCode);
+
+        try {
+            Course courseObject = objectMapper.readValue(rawSectionJSON, Course.class);
+            logger.info("courseObject: {}", courseObject);
+            ConvertedSection convertedSectionObject = courseObject.convertedSections().get(0);
+
+            return convertedSectionObject;
+        } catch (JsonProcessingException jpe) {
+            logger.error("JsonProcessingException:" + jpe);
+            return null;
+        }
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/AddedCoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/AddedCoursesControllerTests.java
@@ -1,0 +1,172 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import edu.ucsb.cs156.courses.repositories.UserRepository;
+import edu.ucsb.cs156.courses.services.CurrentUserService;
+import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
+import edu.ucsb.cs156.courses.testconfig.TestConfig;
+import edu.ucsb.cs156.courses.ControllerTestCase;
+import edu.ucsb.cs156.courses.entities.AddedCourse;
+import edu.ucsb.cs156.courses.entities.PersonalSchedule;
+import edu.ucsb.cs156.courses.entities.User;
+import edu.ucsb.cs156.courses.repositories.PersonalScheduleRepository;
+import edu.ucsb.cs156.courses.repositories.AddedCourseRepository;
+
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import com.mongodb.DuplicateKeyException;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doNothing;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.courses.models.CurrentUser;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+@WebMvcTest(controllers = AddedCoursesController.class)
+@Import(TestConfig.class)
+public class AddedCoursesControllerTests extends ControllerTestCase {
+
+    @MockBean
+    PersonalScheduleRepository personalscheduleRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @MockBean
+    AddedCourseRepository addedCourseRepository;
+
+    @MockBean
+    UCSBCurriculumService ucsbcirService;
+
+    @MockBean
+    CurrentUserService currentUserService;
+
+    @Autowired
+    public ObjectMapper mapper;
+
+    @Test
+    public void sections_admin_all__logged_out__returns_403() throws Exception {
+        mockMvc.perform(get("/api/addedcourses/admin?id=1"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void sections_admin_all__user_logged_in__returns_403() throws Exception {
+        mockMvc.perform(get("/api/addedcourses/admin?id=1"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void sections__user_logged_in__returns_404() throws Exception {
+        mockMvc.perform(get("/api/addedcourses2?id=1"))
+                .andExpect(status().is(404));
+    }
+
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void sections_admin_logged_in__returns_404() throws Exception {
+        mockMvc.perform(get("/api/addedcourses/admin?id=1"))
+                .andExpect(status().is(404));
+    }
+
+
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void sections_admin_all_id_does_not_exist() throws Exception {
+
+        when(addedCourseRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(get("/api/addedcourses/admin?id=7"))
+                                .andExpect(status().is(404)).andReturn();
+
+        verify(personalscheduleRepository, times(1)).findById(eq(7L));
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("EntityNotFoundException", json.get("type"));
+        assertEquals("PersonalSchedule with id 7 not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void sections_admin_return_OK() throws Exception {
+
+        User u1 = User.builder().id(1L).build();
+
+        PersonalSchedule personalSchedule = PersonalSchedule.builder().name("Ryan").description("Test").quarter("2022W").user(u1).id(1L).build();
+        when(personalscheduleRepository.findById(1L)).thenReturn(Optional.of(personalSchedule));
+
+        AddedCourse ac1 = AddedCourse.builder().enrollCd("123").personalSchedule(personalSchedule).id(1).build();
+        List<AddedCourse> listac1 = new ArrayList<AddedCourse>();
+        listac1.add(ac1);
+        when(addedCourseRepository.findAllByPersonalSchedule(personalSchedule)).thenReturn(listac1);
+        when(ucsbcirService.getSectionJSON("2022W","123")).thenReturn("Section Test");
+
+        MvcResult response = mockMvc.perform(get("/api/addedcourses/admin?id=1"))
+                                .andExpect(status().isOk()).andReturn();
+
+        verify(personalscheduleRepository, times(1)).findById(eq(1L));
+        String responseString = response.getResponse().getContentAsString();
+        List<String> resultList =  mapper.readValue(responseString, List.class);
+        System.out.println("JSON" + resultList);
+        assertEquals("Section Test", resultList.get(0));
+    }
+
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void sections_user_return_OK() throws Exception {
+        User u1 = User.builder().id(1L).build();
+        CurrentUser curUser = CurrentUser.builder().user(u1).build();
+        when(currentUserService.getCurrentUser()).thenReturn(curUser);
+
+
+        PersonalSchedule personalSchedule = PersonalSchedule.builder().name("Ryan").description("Test").quarter("2022W").user(u1).id(1L).build();
+        when(personalscheduleRepository.findByIdAndUser(1L, u1)).thenReturn(Optional.of(personalSchedule));
+
+        AddedCourse ac1 = AddedCourse.builder().enrollCd("123").personalSchedule(personalSchedule).id(1).build();
+        List<AddedCourse> listac1 = new ArrayList<AddedCourse>();
+        listac1.add(ac1);
+        when(addedCourseRepository.findAllByPersonalSchedule(personalSchedule)).thenReturn(listac1);
+
+        when(ucsbcirService.getSectionJSON("2022W","123")).thenReturn("Section Test");
+
+        MvcResult response = mockMvc.perform(get("/api/addedcourses?id=1"))
+                                .andExpect(status().isOk()).andReturn();
+
+        verify(personalscheduleRepository, times(1)).findByIdAndUser(1L, u1);
+
+        ObjectMapper mapper = new ObjectMapper();
+        String responseString = response.getResponse().getContentAsString();
+        List<String> resultList =  mapper.readValue(responseString, List.class);
+        System.out.println("JSON" + resultList);
+        assertEquals("Section Test", resultList.get(0));
+
+    }
+
+}


### PR DESCRIPTION
# Overview

In this PR, I added an API that takes in a PersonalSchedule object id and returns a list of all the schedules within that schedule. 
I also added tests for ScheduleSectionController

addresses #11 

# Testing Plan using [Swagger](https://s22-5pm-2-courses-qa.herokuapp.com/swagger-ui/index.html#/)
- Create a personal schedule (with the __/api/personalschedules/post__ endpoint) if you don't already have one. Take note of the psId and the quarter
- In another window, get a few valid enrollCd's for that quarter.
- In Swagger, use the __/api/addedcourses/post__ endpoint to add a few courses to that personal schedule
- Go to the __/api/addedcourses__ endpoint and enter the psId. You should see JSON that has section information about each of the enrollCds on the personal schedule.