### PR TITLE
s22-5pm-1 Adding section number to table

### DIFF
--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -2,6 +2,7 @@ import React from "react";
 import OurTable from "main/components/OurTable";
 
 import { yyyyqToQyy } from "main/utils/quarterUtilities";
+import { boldIfNotSection } from "main/utils/sectionUtils";
 
 export default function SectionsTable({ sections }) {
 
@@ -13,7 +14,8 @@ export default function SectionsTable({ sections }) {
         },
         {
             Header: 'Section',
-            accessor: 'section.section',
+            accessor: (row, _rowIndex) => boldIfNotSection(row.section.section),
+            id: 'section.section',
         },
         {
             Header: 'Course Number',

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -12,6 +12,10 @@ export default function SectionsTable({ sections }) {
             id: 'quarter',
         },
         {
+            Header: 'Section',
+            accessor: 'section.section',
+        },
+        {
             Header: 'Course Number',
             accessor: 'courseInfo.courseId',
         },

--- a/frontend/src/main/utils/sectionUtils.js
+++ b/frontend/src/main/utils/sectionUtils.js
@@ -1,0 +1,20 @@
+
+
+const boldIfNotSection = (code) => {
+    let num = parseInt(code);
+    if (isNaN(num)) {
+        throw new Error("param should be a number");
+    }
+    else if (num % 100 !== 0) {
+        return code;
+    }
+    else {
+        return (
+          <div style={{fontWeight: "bold"}}>{code}</div>
+        )
+    }
+}
+
+export {
+    boldIfNotSection
+};

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -71,9 +71,9 @@ describe("UserTable tests", () => {
             </QueryClientProvider>
         );
 
-        const expectedHeaders = ["Quarter", "Course Number", "Course Title", "Days", "Begin Time", "End Time", 
+        const expectedHeaders = ["Quarter", "Section", "Course Number", "Course Title", "Days", "Begin Time", "End Time", 
         "Enrolled", "Max. Enrollment"];
-        const expectedFields = ["quarter", "courseInfo.courseId", "courseInfo.title", "section.timeLocations[0].days", 
+        const expectedFields = ["quarter", "section.section", "courseInfo.courseId", "courseInfo.title", "section.timeLocations[0].days", 
         "section.timeLocations[0].beginTime", "section.timeLocations[0].endTime", "section.enrolledTotal", "section.maxEnroll"];
         const testId = "SectionsTable";
 
@@ -88,7 +88,7 @@ describe("UserTable tests", () => {
         });
 
         await waitFor( ()=> expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("CMPSC 8"));
-        expect(screen.getByTestId(`${testId}-cell-row-1-col-quarter`)).toHaveTextContent("F20");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("F20");
 
     });
 
@@ -104,9 +104,9 @@ describe("UserTable tests", () => {
             </QueryClientProvider>
         );
 
-        const expectedHeaders = ["Quarter", "Course Number", "Course Title", "Days", "Begin Time", "End Time", 
+        const expectedHeaders = ["Quarter", "Section", "Course Number", "Course Title", "Days", "Begin Time", "End Time", 
         "Enrolled", "Max. Enrollment"];
-        const expectedFields = ["quarter", "courseInfo.courseId", "courseInfo.title", "section.timeLocations[0].days",                        
+        const expectedFields = ["quarter", "section.section", "courseInfo.courseId", "courseInfo.title", "section.timeLocations[0].days",                        
         "section.timeLocations[0].beginTime", "section.timeLocations[0].endTime", "section.enrolledTotal", "section.maxEnroll"];
         const testId = "SectionsTable";
 
@@ -121,7 +121,7 @@ describe("UserTable tests", () => {
         });
 
         await waitFor( () => expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("CMPSC 8"));
-        expect(screen.getByTestId(`${testId}-cell-row-1-col-quarter`)).toHaveTextContent("F20");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("F20");
 
     });
     

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -89,6 +89,7 @@ describe("UserTable tests", () => {
 
         await waitFor( ()=> expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("CMPSC 8"));
         expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("F20");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-section.section`)).toHaveTextContent("0101");
 
     });
 
@@ -122,6 +123,7 @@ describe("UserTable tests", () => {
 
         await waitFor( () => expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("CMPSC 8"));
         expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("F20");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-section.section`)).toHaveTextContent("0101");
 
     });
     

--- a/frontend/src/tests/utils/sectionUtils.test.js
+++ b/frontend/src/tests/utils/sectionUtils.test.js
@@ -1,0 +1,9 @@
+import { boldIfNotSection } from "main/utils/sectionUtils";
+
+describe("To bold tests", () => {
+    test("If correct number bolds", () => {
+        expect(boldIfNotSection("2000")).toStrictEqual(<div style={{fontWeight: "bold"}}>2000</div>);
+        expect(() => {boldIfNotSection("abc"); }).toThrow("param should be a number");
+        expect(boldIfNotSection("2002")).toBe("2002");
+    });
+});


### PR DESCRIPTION
In this pull request, we added a Section column to the table to display section ID as well as bolded the numbers that represent course
Storybook: https://ucsb-cs156-s22.github.io/s22-5pm-courses-docs-qa/storybook-qa/5pm-1-AddingSectionNumberToTable/?path=/story/components-sections-sectionstable--three-sections
<img width="1315" alt="image" src="https://user-images.githubusercontent.com/77415714/172044237-81c82829-e0c4-4122-a59b-94c28564f40d.png">

Test Plan:
Click on section search
Pick a random quarter, class, and course level.
Classes should be displayed properly with the sections column showing up and sections ending in xx00 being bolded.