### PR TITLE
s22-5pm-1 format enrollment

### DIFF
--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -2,7 +2,7 @@ import React from "react";
 import OurTable from "main/components/OurTable";
 
 import { yyyyqToQyy } from "main/utils/quarterUtilities";
-import { boldIfNotSection } from "main/utils/sectionUtils";
+import { boldIfNotSection, fraction_w_percent } from "main/utils/sectionUtils";
 
 export default function SectionsTable({ sections }) {
 
@@ -39,12 +39,13 @@ export default function SectionsTable({ sections }) {
         },
         {
             Header: 'Enrolled',
-            accessor: 'section.enrolledTotal',
+            accessor: (row, _rowIndex) => fraction_w_percent(row.section.enrolledTotal, row.section.maxEnroll),
+            id: 'enrolled'
         },
         {
-            Header: 'Max. Enrollment',
-            accessor: 'section.maxEnroll',
-        },
+            Header: "Enroll Code",
+            accessor: 'section.enrollCode'
+        }
     ];
 
     return <OurTable

--- a/frontend/src/main/utils/sectionUtils.js
+++ b/frontend/src/main/utils/sectionUtils.js
@@ -15,6 +15,19 @@ const boldIfNotSection = (code) => {
     }
 }
 
+const fraction_w_percent = (num, denom) => {
+    if ((num === null) || (denom === null)) {
+        if (denom !== null) {
+            return denom;
+        }
+        return '';
+    }
+    let percent = (parseInt(num) / parseInt(denom)) * 100;
+    percent = percent.toFixed();
+    return `${num}/${denom} (${percent}%)`;
+}
+
 export {
-    boldIfNotSection
+    boldIfNotSection,
+    fraction_w_percent
 };

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -72,9 +72,9 @@ describe("UserTable tests", () => {
         );
 
         const expectedHeaders = ["Quarter", "Section", "Course Number", "Course Title", "Days", "Begin Time", "End Time", 
-        "Enrolled", "Max. Enrollment"];
+        "Enrolled", "Enroll Code"];
         const expectedFields = ["quarter", "section.section", "courseInfo.courseId", "courseInfo.title", "section.timeLocations[0].days", 
-        "section.timeLocations[0].beginTime", "section.timeLocations[0].endTime", "section.enrolledTotal", "section.maxEnroll"];
+        "section.timeLocations[0].beginTime", "section.timeLocations[0].endTime", "enrolled", "section.enrollCode"];
         const testId = "SectionsTable";
 
         expectedHeaders.forEach((headerText) => {
@@ -90,6 +90,7 @@ describe("UserTable tests", () => {
         await waitFor( ()=> expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("CMPSC 8"));
         expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("F20");
         expect(screen.getByTestId(`${testId}-cell-row-0-col-section.section`)).toHaveTextContent("0101");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("27/25 (108%)");
 
     });
 
@@ -106,9 +107,9 @@ describe("UserTable tests", () => {
         );
 
         const expectedHeaders = ["Quarter", "Section", "Course Number", "Course Title", "Days", "Begin Time", "End Time", 
-        "Enrolled", "Max. Enrollment"];
+        "Enrolled", "Enroll Code"];
         const expectedFields = ["quarter", "section.section", "courseInfo.courseId", "courseInfo.title", "section.timeLocations[0].days",                        
-        "section.timeLocations[0].beginTime", "section.timeLocations[0].endTime", "section.enrolledTotal", "section.maxEnroll"];
+        "section.timeLocations[0].beginTime", "section.timeLocations[0].endTime", "enrolled", "section.enrollCode"];
         const testId = "SectionsTable";
 
         expectedHeaders.forEach((headerText) => {
@@ -124,7 +125,7 @@ describe("UserTable tests", () => {
         await waitFor( () => expect(screen.getByTestId(`${testId}-cell-row-0-col-courseInfo.courseId`)).toHaveTextContent("CMPSC 8"));
         expect(screen.getByTestId(`${testId}-cell-row-0-col-quarter`)).toHaveTextContent("F20");
         expect(screen.getByTestId(`${testId}-cell-row-0-col-section.section`)).toHaveTextContent("0101");
-
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-enrolled`)).toHaveTextContent("27/25 (108%)");
     });
     
 });

--- a/frontend/src/tests/utils/sectionUtils.test.js
+++ b/frontend/src/tests/utils/sectionUtils.test.js
@@ -1,9 +1,15 @@
-import { boldIfNotSection } from "main/utils/sectionUtils";
+import { boldIfNotSection, fraction_w_percent } from "main/utils/sectionUtils";
 
-describe("To bold tests", () => {
+describe("Section Util tests", () => {
     test("If correct number bolds", () => {
         expect(boldIfNotSection("2000")).toStrictEqual(<div style={{fontWeight: "bold"}}>2000</div>);
         expect(() => {boldIfNotSection("abc"); }).toThrow("param should be a number");
         expect(boldIfNotSection("2002")).toBe("2002");
+    });
+    test("fraction with percent test", () => {
+        expect(fraction_w_percent(null, null)).toBe("");
+        expect(fraction_w_percent(null, "44")).toBe("44");
+        expect(fraction_w_percent("10", "101")).toBe("10/101 (10%)");
+        expect(fraction_w_percent('2', null)).toBe("");
     });
 });


### PR DESCRIPTION
Added the enrollment column to display in a nice fraction rather than seperate column. Enroll code added as I felt it was important.
<img width="1340" alt="image" src="https://user-images.githubusercontent.com/77415714/172049133-62e886ca-db8b-402b-b2b0-84d0396dcefe.png">

Test Plan:
* Click on section search

* Search for a random section by choosing any quarter, courseCode, and courseLevel.

* The Enrollment column should show a fraction of the total enrolled over the max seats available and give a percentage.

* Some rows will return empty as either total enrolled or max seats are null.

* Some rows will have a single number(total seats)  if max seats is not null and total enrolled is null
Nan/Nan (Nan%) shouldn't appear for any of the rows.

* Enroll Code Column should be visible with codes for each column.