### PR TITLE
s22-5pm-2 JJ - Fixed wrong section being returned in UCSBCurriculumService.getConvertedSection

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -170,9 +170,14 @@ public class UCSBCurriculumService  {
         try {
             Course courseObject = objectMapper.readValue(rawSectionJSON, Course.class);
             logger.info("courseObject: {}", courseObject);
-            ConvertedSection convertedSectionObject = courseObject.convertedSections().get(0);
 
-            return convertedSectionObject;
+            for (ConvertedSection cs: courseObject.convertedSections()) {
+                if (cs.getSection().getEnrollCode().equals(enrollCode)) {
+                    return cs;
+                }
+            }
+
+            return null;
         } catch (JsonProcessingException jpe) {
             logger.error("JsonProcessingException:" + jpe);
             return null;

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBCurriculumServiceTests.java
@@ -215,7 +215,7 @@ public class UCSBCurriculumServiceTests {
         String result = ucs.getSectionJSON(quarter, enrollCode);
         assertEquals(expectedResult, result);
     }
-  
+
     @Test
     public void test_getConvertedSections() throws Exception {
         String expectedResult = CoursePageFixtures.COURSE_PAGE_JSON_MATH3B;
@@ -238,9 +238,9 @@ public class UCSBCurriculumServiceTests {
 
         ObjectMapper objectMapper = new ObjectMapper();
         String convertedSectionsString = ucs.getConvertedSectionsJSON(subjectArea, quarter, level);
-        List<ConvertedSection> convertedSections = objectMapper.readValue(convertedSectionsString, 
+        List<ConvertedSection> convertedSections = objectMapper.readValue(convertedSectionsString,
                 new TypeReference<List<ConvertedSection>>() {
-                });            
+                });
         List<ConvertedSection> expected = objectMapper.readValue(CoursePageFixtures.CONVERTED_SECTIONS_JSON_MATH5B,
                 new TypeReference<List<ConvertedSection>>() {
                 });
@@ -294,6 +294,27 @@ public class UCSBCurriculumServiceTests {
     public void test_getSection_with_ConvertedSections_json_exception() throws Exception {
 
         String jsonAPIResponse = "bad format";
+
+        String quarter = "20221";
+        String enrollCode = "00018";
+
+        String expectedURL = UCSBCurriculumService.SECTION_ENDPOINT.replace("{quarter}", quarter).replace("{enrollCode}", enrollCode);
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+            .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+            .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+            .andExpect(header("ucsb-api-version", "1.0"))
+            .andExpect(header("ucsb-api-key", apiKey))
+            .andRespond(withSuccess(jsonAPIResponse, MediaType.APPLICATION_JSON));
+
+        ConvertedSection result = ucs.getConvertedSection(quarter, enrollCode);
+        assertNull(result);
+    }
+
+    @Test
+    public void test_getSection_with_ConvertedSections_enroll_code_not_found() throws Exception {
+
+        String jsonAPIResponse = "{ \"classSections\": [ {\"enrollCode\": \"99999\"} ] }";
 
         String quarter = "20221";
         String enrollCode = "00018";


### PR DESCRIPTION
# Overview

Fixed a bug where the incorrect section for a course would be returned for a given enrollCode in UCSBCurriculumService. getConvertedSection

# Issues Addressed

#67 

# Testing Plan using [Swagger](https://s22-5pm-2-courses-qa.herokuapp.com/swagger-ui/index.html#/)
- Create a personal schedule (with the __/api/personalschedules/post__ endpoint) if you don't already have one. Take note of the psId and the quarter
- In another window, get a few valid enrollCd's for that quarter. Make sure to include multiple enroll codes from the same course.
- In Swagger, use the __/api/addedcourses/post__ endpoint to add a few courses to that personal schedule
- Go to the __/api/addedcourses/all__ endpoint and enter the psId. You should see JSON that has section information about each of the enrollCds on the personal schedule. Ensure that the correct enrollCodes are present, especially if they are in the same course.
